### PR TITLE
feat: add joystick support

### DIFF
--- a/sjtu_drone_bringup/launch/sjtu_drone_bringup.launch.py
+++ b/sjtu_drone_bringup/launch/sjtu_drone_bringup.launch.py
@@ -24,18 +24,22 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 def get_teleop_controller(controller: str, namespace: str) -> Node:
-    node = Node(
-        package="sjtu_drone_control",
-        namespace=namespace,
-        output="screen"
-    )
-
-    if controller == 'joystick':
-        node.executable = "teleop_joystick"
+    if controller == "joystick":
+        node = Node(
+            package="sjtu_drone_control",
+            executable="teleop_joystick",
+            namespace=namespace,
+            output="screen"
+        )
 
     else:
-        node.executable = "teleop"
-        node.prefix = "xterm-e"
+        node = Node(
+            package="sjtu_drone_control",
+            executable="teleop",
+            namespace=namespace,
+            output="screen",
+            prefix="xterm -e"
+        )
 
     return node
 

--- a/sjtu_drone_bringup/launch/sjtu_drone_bringup.launch.py
+++ b/sjtu_drone_bringup/launch/sjtu_drone_bringup.launch.py
@@ -31,7 +31,7 @@ def get_teleop_controller(context, *_, **kwargs) -> Node:
             package="sjtu_drone_control",
             executable="teleop_joystick",
             namespace=namespace,
-            output="screen"
+            output="screen",
         )
 
     else:
@@ -40,7 +40,7 @@ def get_teleop_controller(context, *_, **kwargs) -> Node:
             executable="teleop",
             namespace=namespace,
             output="screen",
-            prefix="xterm -e"
+            prefix="xterm -e",
         )
 
     return [node]
@@ -67,7 +67,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "controller",
             default_value="keyboard",
-            description="Type of controller: keyboard (default) or joystick"
+            description="Type of controller: keyboard (default) or joystick",
         ),
 
         Node(
@@ -77,7 +77,7 @@ def generate_launch_description():
             arguments=[
                 "-d", rviz_path
             ],
-            output="screen"
+            output="screen",
         ),
 
         IncludeLaunchDescription(
@@ -96,6 +96,6 @@ def generate_launch_description():
 
         OpaqueFunction(
             function=get_teleop_controller,
-            kwargs={'model_ns': model_ns}
-        )
+            kwargs={'model_ns': model_ns},
+        ),
     ])

--- a/sjtu_drone_control/package.xml
+++ b/sjtu_drone_control/package.xml
@@ -11,10 +11,12 @@
   <depend>geometry_msgs</depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
+  <depend>joy</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>  <maintainer email="georg.novtony@aon.at">ubuntu</maintainer>
+  <test_depend>ament_pep257</test_depend>
+  <maintainer email="georg.novtony@aon.at">ubuntu</maintainer>
 
   <test_depend>python3-pytest</test_depend>
 

--- a/sjtu_drone_control/setup.py
+++ b/sjtu_drone_control/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'teleop = sjtu_drone_control.teleop:main',
+            'teleop_joystick = sjtu_drone_control.teleop_joystick:main',
             'open_loop_control = sjtu_drone_control.open_loop_control:main',
             'drone_position_control = sjtu_drone_control.drone_position_control:main'
         ],

--- a/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
+++ b/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
@@ -32,7 +32,6 @@ class TeleopNode(Node):
         self.takeoff_publisher = self.create_publisher(Empty, 'takeoff', 10)
         self.land_publisher = self.create_publisher(Empty, 'land', 10)
 
-
     def joy_callback(self, msg: Joy) -> None:
         """
         Callback for joystick input

--- a/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
+++ b/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
@@ -88,7 +88,7 @@ class TeleopNode(Node):
             self.takeoff_publisher.publish(Empty())
         elif msg.buttons[1] == 1:
             # Land
-            self.publish_cmd_vel()
+            self.cmd_vel_publisher.publish(Twist())
             self.land_publisher.publish(Empty())
 
 

--- a/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
+++ b/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2023 Georg Novotny
+#
+# Licensed under the GNU GENERAL PUBLIC LICENSE, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gnu.org/licenses/gpl-3.0.en.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from geometry_msgs.msg import Twist, Vector3
+from rclpy.node import Node
+from sensor_msgs.msg import Joy
+from std_msgs.msg import Empty
+
+
+class TeleopNode(Node):
+    def __init__(self) -> None:
+        super().__init__('teleop_node')
+
+        # Subscribers
+        self.joy_subscriber = self.create_subscription(Joy, 'joy', self.joy_callback, 10)
+
+        # Publishers
+        self.cmd_vel_publisher = self.create_publisher(Twist, 'cmd_vel', 10)
+        self.takeoff_publisher = self.create_publisher(Empty, 'takeoff', 10)
+        self.land_publisher = self.create_publisher(Empty, 'land', 10)
+
+        # Velocity parameters
+        self.linear_velocity = 0.0
+        self.angular_velocity = 0.0
+        self.linear_increment = 0.05
+        self.angular_increment = 0.05
+        self.max_linear_velocity = 1.0
+        self.max_angular_velocity = 1.0
+
+        self.joy_axes = []
+        self.joy_buttons = []
+
+        # Start a timer to listen to keyboard inputs
+        self.create_timer((0.005), self.read_joystick_input)
+
+    def clip(self, value: float, max_val: float) -> float:
+        return -max_val if value < -max_val else max_val if value > max_val else value
+
+    def get_velocity_msg(self) -> str:
+        return f"Linear Velocity: {self.linear_velocity}\nAngular Velocity: {self.angular_velocity}\n"
+
+    def read_joystick_input(self) -> None:
+        """
+        Read keyboard inputs and publish corresponding commands
+        """
+        while rclpy.ok():
+            # Print the instructions
+            print(self.get_velocity_msg())
+            # Handle velocity changes
+            self.linear_velocity = self.clip(self.linear_velocity + (self.joy_axes[3] * self.linear_increment),
+                                       self.max_linear_velocity)
+            self.angular_velocity = self.clip(self.angular_velocity + (self.joy_axes[3] * self.angular_increment),
+                                        self.max_angular_velocity)
+
+            linear_vec = Vector3()
+            linear_vec.x = self.joy_axes[1] * self.linear_velocity
+            linear_vec.y = self.joy_axes[0] * self.linear_velocity
+            linear_vec.z = self.linear_velocity
+
+            angular_vec = Vector3()
+            angular_vec.z = self.joy_axes[2] * self.angular_velocity
+
+            self.publish_cmd_vel(linear_vec, angular_vec)
+
+            # Handle other keys for different movements
+            if self.joy_buttons[0] == 1:
+                # Takeoff
+                self.takeoff_publisher.publish(Empty())
+            elif self.joy_buttons[1] == 1:
+                # Land
+                self.publish_cmd_vel()
+                self.land_publisher.publish(Empty())
+
+    def joy_callback(self, msg: Joy) -> None:
+        """
+        Callback for joystick input
+
+        BUTTONS
+        -------
+        0 	A (CROSS)
+        1 	B (CIRCLE)
+        2 	X (SQUARE)
+        3 	Y (TRIANGLE)
+        4 	BACK (SELECT)
+        5 	GUIDE (Middle/Manufacturer Button)
+        6 	START
+        7 	LEFTSTICK
+        8 	RIGHTSTICK
+        9 	LEFTSHOULDER
+        10 	RIGHTSHOULDER
+        11 	DPAD_UP
+        12 	DPAD_DOWN
+        13 	DPAD_LEFT
+        14 	DPAD_RIGHT
+        15 	MISC1 (Depends on the controller manufacturer, but is usually at a similar location on the controller as back/start)
+        16 	PADDLE1 (Upper left, facing the back of the controller if present)
+        17 	PADDLE2 (Upper right, facing the back of the controller if present)
+        18 	PADDLE3 (Lower left, facing the back of the controller if present)
+        19 	PADDLE4 (Lower right, facing the back of the controller if present)
+        20 	TOUCHPAD (If present. Button status only)
+
+        AXES
+        ----
+        0 	LEFTX
+        1 	LEFTY
+        2 	RIGHTX
+        3 	RIGHTY
+        4 	TRIGGERLEFT
+        5 	TRIGGERRIGHT
+        """
+        self.joy_axes = msg.axes
+        self.joy_buttons = msg.buttons
+
+    def publish_cmd_vel(self, linear_vec: Vector3, angular_vec: Vector3) -> None:
+        """
+        Publish a Twist message to cmd_vel topic
+        """
+        twist = Twist(linear=linear_vec, angular=angular_vec)
+        self.cmd_vel_publisher.publish(twist)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    teleop_node = TeleopNode()
+    rclpy.spin(teleop_node)
+    teleop_node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
+++ b/sjtu_drone_control/sjtu_drone_control/teleop_joystick.py
@@ -32,8 +32,6 @@ class TeleopNode(Node):
         self.takeoff_publisher = self.create_publisher(Empty, 'takeoff', 10)
         self.land_publisher = self.create_publisher(Empty, 'land', 10)
 
-    def get_velocity_msg(self) -> str:
-        return f"Linear Velocity: {self.linear_velocity}\nAngular Velocity: {self.angular_velocity}\n"
 
     def joy_callback(self, msg: Joy) -> None:
         """


### PR DESCRIPTION
## Summary

Depends on ROS2's `joy` package to add universal Linux-only joystick support. Queue size is set to zero because we only always want the latest inputs from the controller. Tested on an Xbox and Nintendo controller.

## Usage

```bash
ros2 launch sjtu_drone_bringup sjtu_drone_bringup.launch.py controller:="joystick"
```

Let me know if any changes are required.

Closes #12