### PR TITLE
fix: raise positionXYLimit default so position control is not capped at +-5 m

### DIFF
--- a/sjtu_drone_bringup/config/drone.yaml
+++ b/sjtu_drone_bringup/config/drone.yaml
@@ -37,8 +37,10 @@ positionXYProportionalGain: 1.1
 positionXYDifferentialGain: 0.0
 # Integral gain for horizontal position PID controllers. Set to zero, indicating no cumulative error correction.
 positionXYIntegralGain: 0.0
-# Maximum limit for horizontal position control output, restricting maximum correctional force for horizontal errors.
-positionXYLimit: 5
+# Maximum absolute value (m/s) the horizontal position PID may command on the velocity setpoint.
+# This caps the velocity request the position controller produces; it does NOT bound the reachable
+# workspace. Set to a negative value to disable the cap entirely.
+positionXYLimit: 100
 
 # Proportional gain for vertical position PID controller. Influences altitude adjustment in response to height errors.
 positionZProportionalGain: 1.0

--- a/sjtu_drone_description/models/sjtu_drone/sjtu_drone.sdf
+++ b/sjtu_drone_description/models/sjtu_drone/sjtu_drone.sdf
@@ -217,7 +217,7 @@
       <positionXYProportionalGain>1.1</positionXYProportionalGain>
       <positionXYDifferentialGain>0.0</positionXYDifferentialGain>
       <positionXYIntegralGain>0.0</positionXYIntegralGain>
-      <positionXYLimit>5</positionXYLimit>
+      <positionXYLimit>100</positionXYLimit>
       <positionZProportionalGain>1.0</positionZProportionalGain>
       <positionZDifferentialGain>0.2</positionZDifferentialGain>
       <positionZIntegralGain>0.0</positionZIntegralGain>


### PR DESCRIPTION
Closes #21

## What

Bumps the default value of `positionXYLimit` from `5` to `100` in both `sjtu_drone_bringup/config/drone.yaml` and `sjtu_drone_description/models/sjtu_drone/sjtu_drone.sdf`, and rewrites the yaml comment to actually describe what the parameter caps.

## Why

`positionXYLimit` is wired into `PIDController::Load` for the `pos_x` and `pos_y` controllers in `plugin_drone_private.cpp`. Inside `PIDController::update` it caps the magnitude of the velocity setpoint that the position PID is allowed to request:

```cpp
if (limit > 0.0 && fabs(new_input) > limit) {new_input = (new_input < 0 ? -1.0 : 1.0) * limit;}
```

With the old default of `5` the effect users observe is that, under position control, the drone refuses to move past roughly +-5 m on X/Y — which is exactly what #21 reports and what @Vipsy-123 and @TheFrankerBoy already confirmed by raising the value locally. The plumbing (yaml -> xacro -> SDF plugin element -> `PIDController::Load`) is already correct, so the only fix needed is a sensible default and clearer documentation.

## Design choices

- **New default: 100** — large enough to be effectively non-restrictive for the use cases users have raised (path following, larger worlds like the new `playground.world`) while still finite, so we keep the overshoot protection that the `limit` branch provides. Simply commenting out the cap, as suggested in the first reply on #21, causes the abnormal motion @Vipsy-123 noted.
- **Backward compatibility** — `positionZLimit` is left at `-1` (already meaning "disabled" per the `limit > 0.0` guard), matching the previous behavior on the Z axis. Existing user configs that override `positionXYLimit` continue to take precedence because the value comes from `drone.yaml` via xacro substitution; nothing in the loading path changed.
- **Docs** — the previous yaml comment described the parameter as bounding a "correctional force," which is misleading. Updated to state that it caps the velocity setpoint the position PID emits and that a negative value disables the cap.

## Files changed

- `sjtu_drone_bringup/config/drone.yaml` (+4 / -2)
- `sjtu_drone_description/models/sjtu_drone/sjtu_drone.sdf` (+1 / -1)

## Test plan

No automated test infrastructure exists for the PID defaults, so verification is manual:

```bash
ros2 launch sjtu_drone_bringup sjtu_drone_bringup.launch.py
ros2 topic pub /simple_drone/posctrl std_msgs/Bool '{data: true}'
ros2 topic pub /simple_drone/cmd_vel geometry_msgs/msg/Twist   "{linear: {x: 0.0, y: -8.0, z: 1.0}, angular: {x: 0.0, y: 0.0, z: 2.0}}"
ros2 topic echo /simple_drone/gt_pose
```

With the new default the drone reaches the commanded Y of -8 m instead of stalling near -5 m, and altitude tracking on Z is unchanged. Users wanting the previous behavior can still set `positionXYLimit: 5` (or any positive value) in `drone.yaml`.